### PR TITLE
Add IDs for Quick Edit form elements

### DIFF
--- a/assets/Editor.js
+++ b/assets/Editor.js
@@ -2,13 +2,13 @@ import React from 'react';
 
 export default class Editor extends React.Component {
 	render() {
-		const { value, onChange } = this.props;
+		const { id, value, onChange } = this.props;
 
 		return <div id="wp-replycontent-wrap" className="wp-core-ui wp-editor-wrap html-active">
 			<div id="wp-replycontent-editor-container" className="wp-editor-container">
 				<textarea
 					className="wp-editor-area"
-					id="replycontent"
+					id={ id }
 					rows={ 20 }
 					cols={ 40 }
 					value={ value }
@@ -18,3 +18,6 @@ export default class Editor extends React.Component {
 		</div>;
 	}
 }
+Editor.defaultProps = {
+	id: "replycontent",
+};

--- a/assets/QuickEdit.js
+++ b/assets/QuickEdit.js
@@ -2,6 +2,8 @@ import React from 'react';
 
 import Editor from './Editor';
 
+const inputId = id => `quickedit-${id}`;
+
 export default class QuickEdit extends React.Component {
 	constructor(props) {
 		super(props);
@@ -71,8 +73,9 @@ export default class QuickEdit extends React.Component {
 				<legend>{ heading }</legend>
 
 				<div id="replycontainer">
-					<label className="screen-reader-text">Comment</label>
+					<label className="screen-reader-text" htmlFor="replycontent">Comment</label>
 					<Editor
+						id="replycontent"
 						value={ data.content }
 						onChange={ content => this.setState({ content }) }
 					/>
@@ -80,9 +83,10 @@ export default class QuickEdit extends React.Component {
 
 				<div id="edithead">
 					<div className="inside">
-						<label>Name</label>
+						<label htmlFor={ inputId( 'name' ) }>Name</label>
 						{' '}
 						<input
+							id={ inputId( 'name' ) }
 							name="newcomment_author"
 							size="50"
 							type="text"
@@ -92,9 +96,10 @@ export default class QuickEdit extends React.Component {
 					</div>
 
 					<div className="inside">
-						<label>Email</label>
+						<label htmlFor={ inputId( 'email' ) }>Email</label>
 						{' '}
 						<input
+							id={ inputId( 'email' ) }
 							name="newcomment_author_email"
 							size="50"
 							type="text"
@@ -104,9 +109,10 @@ export default class QuickEdit extends React.Component {
 					</div>
 
 					<div className="inside">
-						<label>URL</label>
+						<label htmlFor={ inputId( 'url' ) }>URL</label>
 						{' '}
 						<input
+							id={ inputId( 'url' ) }
 							className="code"
 							name="newcomment_author_url"
 							size="103"


### PR DESCRIPTION
Fixes #7, #8.

For now, I haven't made a generic form ID utility, because all these spots so far have been single-use-only components, and might have compatibility concerns that we need to fix in the future. If need be, we can always change them later.