### PR TITLE
Updated location of git repo in Building steps

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ The NLT project is built in React, and requires a build process via tools availa
 1. Clone the project via git into your plugins directory:
 
    ```
-   git clone https://github.com/rmccue/new-list-table
+   git clone https://github.com/WP-API/new-list-tables
    ```
 
 2. Install the npm dependencies:


### PR DESCRIPTION
I know the old repo url is pointing to the new one, but my OCD wouldn't let me leave it as is.